### PR TITLE
Update documentation.html: fix Install link to github

### DIFF
--- a/contents/documentation/documentation.html
+++ b/contents/documentation/documentation.html
@@ -21,11 +21,7 @@ Documentation for McXtrace is available in some different ways:
 Installation 
 </h1>
 <ul>
-  <li><a href="https://github.com/mccode-dev/McCode/tree/master/INSTALL-McXtrace-1.x">Installation instructions for McXtrace 1.7.1</a>
-  <li><a href="https://github.com/mccode-dev/McCode/tree/master/INSTALL-McXtrace-3.x">Installation instructions for McXtrace 3.1</a>
+  <li><a href="https://github.com/mccode-dev/McCode/tree/main/INSTALL-McXtrace">Installation instructions for McXtrace</a>
 </ul>
-<h1>
-Other documentation links:
-</h1>
 
 </body></html>


### PR DESCRIPTION
I'm fixing the installation link in mcxtrace.org web site / 'documentation'